### PR TITLE
fix error with import_lib metadata statement

### DIFF
--- a/cdk_lambda_layer_builder/constructs.py
+++ b/cdk_lambda_layer_builder/constructs.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 import zipfile
 import os
 import shutil
-from importlib.metadata import version
+from importlib_metadata import version
 
 
 class PyLayerVersion(aws_lambda.LayerVersion):


### PR DESCRIPTION


importation of 'importlib_metadata' changed from 'import.metadata' to 'import_metadata' in construct.py. The import statement was incorrect for python3.7 and 3.8. Not yet tested on 3.9 and 3.10.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
